### PR TITLE
전입 신고 API 구현 #3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,13 +25,25 @@ repositories {
 }
 
 dependencies {
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.mysql:mysql-connector-j'
-	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
+	// MySQL
+	runtimeOnly 'com.mysql:mysql-connector-j'
+
+	// Lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// Swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/config/SwaggerConfig.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/config/SwaggerConfig.java
@@ -1,0 +1,17 @@
+package teamkim.barrier_free_kiosk_spring.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+                .info(new Info().title("Barrier Free Kiosk Server"))
+                .addServersItem(new Server().url("/"));
+    }
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/controller/KioskController.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/controller/KioskController.java
@@ -1,0 +1,25 @@
+package teamkim.barrier_free_kiosk_spring.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import teamkim.barrier_free_kiosk_spring.dto.MoveInReportReqDto;
+import teamkim.barrier_free_kiosk_spring.service.KioskService;
+
+@RestController
+@RequestMapping("/api")
+@RequiredArgsConstructor
+public class KioskController {
+    private final KioskService kioskService;
+
+    @PostMapping("/move-in")
+    @Operation(summary = "전입 신고 API")
+    public ResponseEntity<Long> postMoveInReport(@Valid @RequestBody MoveInReportReqDto moveInReportReqDto) {
+        return ResponseEntity.ok(kioskService.registerMoveInReport(moveInReportReqDto));
+    }
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/dto/MoveInReportReqDto.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/dto/MoveInReportReqDto.java
@@ -1,0 +1,21 @@
+package teamkim.barrier_free_kiosk_spring.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import teamkim.barrier_free_kiosk_spring.enums.MoveInReason;
+
+public record MoveInReportReqDto(
+        @NotBlank String name,
+        @NotBlank String phoneNumber,
+        @NotNull MoveInReason reason,
+        @NotNull Address oldAddress,
+        @NotNull Address newAddress
+) {
+    public record Address(
+            @NotBlank String sido,
+            @NotBlank String sigungu,
+            @NotBlank String roadName,
+            @NotNull Integer buildingNumber,
+            @NotNull String detailAddress
+    ) {}
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/dto/MoveInReportReqDto.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/dto/MoveInReportReqDto.java
@@ -1,5 +1,6 @@
 package teamkim.barrier_free_kiosk_spring.dto;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import teamkim.barrier_free_kiosk_spring.enums.MoveInReason;
@@ -8,8 +9,8 @@ public record MoveInReportReqDto(
         @NotBlank String name,
         @NotBlank String phoneNumber,
         @NotNull MoveInReason reason,
-        @NotNull Address oldAddress,
-        @NotNull Address newAddress
+        @NotNull @Valid Address oldAddress,
+        @NotNull @Valid Address newAddress
 ) {
     public record Address(
             @NotBlank String sido,

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/dto/MoveInReportReqDto.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/dto/MoveInReportReqDto.java
@@ -17,6 +17,6 @@ public record MoveInReportReqDto(
             @NotBlank String sigungu,
             @NotBlank String roadName,
             @NotNull Integer buildingNumber,
-            @NotNull String detailAddress
+            @NotNull String detail
     ) {}
 }

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/Address.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/Address.java
@@ -25,7 +25,7 @@ public class Address {
                 address.sigungu(),
                 address.roadName(),
                 address.buildingNumber(),
-                address.detailAddress()
+                address.detail()
         );
     }
 }

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/Address.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/Address.java
@@ -1,0 +1,31 @@
+package teamkim.barrier_free_kiosk_spring.entity;
+
+import jakarta.persistence.Embeddable;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import teamkim.barrier_free_kiosk_spring.dto.MoveInReportReqDto;
+
+@Embeddable
+@AllArgsConstructor
+@NoArgsConstructor
+public class Address {
+    private String sido;
+
+    private String sigungu;
+
+    private String roadName;
+
+    private Integer buildingNumber;
+
+    private String detailAddress;
+
+    public static Address from(MoveInReportReqDto.Address address) {
+        return new Address(
+                address.sido(),
+                address.sigungu(),
+                address.roadName(),
+                address.buildingNumber(),
+                address.detailAddress()
+        );
+    }
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/Log.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/Log.java
@@ -1,0 +1,27 @@
+package teamkim.barrier_free_kiosk_spring.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Inheritance(strategy = InheritanceType.JOINED)
+@DiscriminatorColumn
+@NoArgsConstructor
+public class Log {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    protected User user;
+
+    protected LocalDateTime createdAt;
+
+    protected Log(User user) {
+        this.user = user;
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/MoveInReportLog.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/MoveInReportLog.java
@@ -1,0 +1,51 @@
+package teamkim.barrier_free_kiosk_spring.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import teamkim.barrier_free_kiosk_spring.dto.MoveInReportReqDto;
+import teamkim.barrier_free_kiosk_spring.enums.MoveInReason;
+
+@Entity
+@Getter
+@NoArgsConstructor
+public class MoveInReportLog extends Log {
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "sido", column = @Column(name = "old_sido")),
+            @AttributeOverride(name = "sigungu", column = @Column(name = "old_sigungu")),
+            @AttributeOverride(name = "roadName", column = @Column(name = "old_road_name")),
+            @AttributeOverride(name = "buildingNumber", column = @Column(name = "old_building_number")),
+            @AttributeOverride(name = "detailAddress", column = @Column(name = "old_detail_address"))
+    })
+    private Address oldAddress;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "sido", column = @Column(name = "new_sido")),
+            @AttributeOverride(name = "sigungu", column = @Column(name = "new_sigungu")),
+            @AttributeOverride(name = "roadName", column = @Column(name = "new_road_name")),
+            @AttributeOverride(name = "buildingNumber", column = @Column(name = "new_building_number")),
+            @AttributeOverride(name = "detailAddress", column = @Column(name = "new_detail_address"))
+    })
+    private Address newAddress;
+
+    @Enumerated(EnumType.STRING)
+    private MoveInReason reason;
+
+    public MoveInReportLog(User user, Address oldAddress, Address newAddress, MoveInReason reason) {
+        super(user);
+        this.oldAddress = oldAddress;
+        this.newAddress = newAddress;
+        this.reason = reason;
+    }
+
+    public static MoveInReportLog from(MoveInReportReqDto moveInReportReqDto, User user) {
+        return new MoveInReportLog(
+                user,
+                Address.from(moveInReportReqDto.oldAddress()),
+                Address.from(moveInReportReqDto.newAddress()),
+                moveInReportReqDto.reason()
+        );
+    }
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/User.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/User.java
@@ -1,0 +1,26 @@
+package teamkim.barrier_free_kiosk_spring.entity;
+
+import jakarta.persistence.*;
+import teamkim.barrier_free_kiosk_spring.enums.Gender;
+
+@Entity
+public class User {
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String registrationNumber;
+
+    private String name;
+
+    private String phoneNumber;
+
+    @Enumerated(EnumType.STRING)
+    private Gender gender;
+
+    @Embedded
+    private Address address;
+
+    public void updateAddress(Address address) {
+        this.address = address;
+    }
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/User.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/User.java
@@ -8,10 +8,12 @@ public class User {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(unique = true)
     private String registrationNumber;
 
     private String name;
 
+    @Column(unique = true)
     private String phoneNumber;
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/enums/Gender.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/enums/Gender.java
@@ -1,0 +1,5 @@
+package teamkim.barrier_free_kiosk_spring.enums;
+
+public enum Gender {
+    MALE, FEMALE
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/enums/MoveInReason.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/enums/MoveInReason.java
@@ -1,0 +1,5 @@
+package teamkim.barrier_free_kiosk_spring.enums;
+
+public enum MoveInReason {
+    JOB, FAMILY, HOUSE, EDUCATION, ENVIRONMENT, NATURE, ETC
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/exception/CustomException.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/exception/CustomException.java
@@ -1,0 +1,10 @@
+package teamkim.barrier_free_kiosk_spring.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class CustomException extends RuntimeException {
+    private final ExceptionCode exceptionCode;
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/exception/ExceptionCode.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/exception/ExceptionCode.java
@@ -1,0 +1,14 @@
+package teamkim.barrier_free_kiosk_spring.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ExceptionCode {
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "사용자를 찾을 수 없습니다.");
+
+    private final HttpStatus code;
+    private final String message;
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/exception/GlobalExceptionHandler.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/exception/GlobalExceptionHandler.java
@@ -1,0 +1,15 @@
+package teamkim.barrier_free_kiosk_spring.exception;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(CustomException.class)
+    public ResponseEntity<String> handleCustomException(CustomException e) {
+        ExceptionCode exceptionCode = e.getExceptionCode();
+        return new ResponseEntity<>(exceptionCode.getMessage(), exceptionCode.getCode());
+    }
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/repository/LogRepository.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/repository/LogRepository.java
@@ -1,0 +1,7 @@
+package teamkim.barrier_free_kiosk_spring.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import teamkim.barrier_free_kiosk_spring.entity.Log;
+
+public interface LogRepository extends JpaRepository<Log, Long> {
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/repository/UserRepository.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package teamkim.barrier_free_kiosk_spring.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import teamkim.barrier_free_kiosk_spring.entity.User;
+
+import java.util.Optional;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+    Optional<User> findByPhoneNumberAndName(String phoneNumber, String name);
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/service/KioskService.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/service/KioskService.java
@@ -1,0 +1,32 @@
+package teamkim.barrier_free_kiosk_spring.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import teamkim.barrier_free_kiosk_spring.dto.MoveInReportReqDto;
+import teamkim.barrier_free_kiosk_spring.entity.Address;
+import teamkim.barrier_free_kiosk_spring.entity.MoveInReportLog;
+import teamkim.barrier_free_kiosk_spring.entity.User;
+import teamkim.barrier_free_kiosk_spring.exception.CustomException;
+import teamkim.barrier_free_kiosk_spring.exception.ExceptionCode;
+import teamkim.barrier_free_kiosk_spring.repository.LogRepository;
+import teamkim.barrier_free_kiosk_spring.repository.UserRepository;
+
+@Service
+@RequiredArgsConstructor
+public class KioskService {
+    private final UserRepository userRepository;
+    private final LogRepository logRepository;
+
+    @Transactional
+    public Long registerMoveInReport(MoveInReportReqDto moveInReportReqDto) {
+        User user = userRepository.findByPhoneNumberAndName(moveInReportReqDto.phoneNumber(), moveInReportReqDto.name())
+                .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
+
+        user.updateAddress(Address.from(moveInReportReqDto.newAddress()));
+
+        MoveInReportLog moveInReportLog = logRepository.save(MoveInReportLog.from(moveInReportReqDto, user));
+
+        return moveInReportLog.getId();
+    }
+}


### PR DESCRIPTION
### PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약
전입 신고 API를 구현했습니다.

### 상세 내용
**Request**
```json
{
    "name": "김경북",
    "phoneNumber": "010-1234-5678",
    "reason": "JOB",
    "oldAddress": {
        "sido": "대구광역시",
        "sigungu": "북구",
        "roadName": "대학로",
        "buildingNumber": 80,
        "detail": "융복합관 B101"
    },
    "newAddress": {
        "sido": "대구광역시",
        "sigungu": "북구",
        "roadName": "대학로",
        "buildingNumber": 80,
        "detail": "융복합관 B102"
    }
}
```

**Response**
```
1
```

### 이슈 번호
Resolved #3 

### 스크린샷(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - 전입 신고 API 추가: 신청 정보 접수 후 접수 번호(ID) 반환.
  - 사용자 주소 자동 갱신 및 전입 이력(로그) 저장.

- **Improvements**
  - 서버측 입력 유효성 검사 강화(필수 필드 검증).
  - 사용자 미조회 시 표준화된 오류 응답으로 처리(중앙 예외 처리).

- **Documentation**
  - Swagger/OpenAPI UI 제공으로 브라우저에서 API 문서 확인 및 테스트 가능.

- **Platform**
  - JPA 기반 영속성 지원 및 MySQL 런타임 드라이버 추가.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->