### PR TITLE
주소 조회 API 구현 #10

### DIFF
--- a/src/main/java/teamkim/barrier_free_kiosk_spring/controller/KioskController.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/controller/KioskController.java
@@ -7,9 +7,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
-import teamkim.barrier_free_kiosk_spring.dto.MoveInReportReqDto;
+import teamkim.barrier_free_kiosk_spring.dto.request.MoveInReportReqDto;
 import teamkim.barrier_free_kiosk_spring.service.KioskService;
-import teamkim.barrier_free_kiosk_spring.dto.ResidentRegistrationReqDto;
+import teamkim.barrier_free_kiosk_spring.dto.request.ResidentRegistrationReqDto;
 
 @Validated
 @RestController

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/controller/KioskController.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/controller/KioskController.java
@@ -8,6 +8,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import teamkim.barrier_free_kiosk_spring.dto.request.MoveInReportReqDto;
+import teamkim.barrier_free_kiosk_spring.dto.response.AddressGetResDto;
 import teamkim.barrier_free_kiosk_spring.service.KioskService;
 import teamkim.barrier_free_kiosk_spring.dto.request.ResidentRegistrationReqDto;
 
@@ -30,9 +31,15 @@ public class KioskController {
         return ResponseEntity.ok(kioskService.issueResidentRegistration(residentRegistrationReqDto));
     }
 
-    @GetMapping("/move-in")
+    @GetMapping("/move-in/check")
     @Operation(summary = "전화번호 유효성 체크 API")
     public ResponseEntity<Boolean> getPhoneNumberValidity(@RequestParam @NotBlank String phoneNumber) {
         return ResponseEntity.ok(kioskService.checkPhoneNumber(phoneNumber));
+    }
+
+    @GetMapping("/move-in/address")
+    @Operation(summary = "주소 검색 API")
+    public ResponseEntity<AddressGetResDto> getAddress(@RequestParam @NotBlank String name, @RequestParam @NotBlank String phoneNumber) {
+        return ResponseEntity.ok(kioskService.retrieveAddress(name, phoneNumber));
     }
 }

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/dto/request/MoveInReportReqDto.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/dto/request/MoveInReportReqDto.java
@@ -1,4 +1,4 @@
-package teamkim.barrier_free_kiosk_spring.dto;
+package teamkim.barrier_free_kiosk_spring.dto.request;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/dto/request/ResidentRegistrationReqDto.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/dto/request/ResidentRegistrationReqDto.java
@@ -1,4 +1,4 @@
-package teamkim.barrier_free_kiosk_spring.dto;
+package teamkim.barrier_free_kiosk_spring.dto.request;
 
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/dto/response/AddressGetResDto.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/dto/response/AddressGetResDto.java
@@ -1,0 +1,22 @@
+package teamkim.barrier_free_kiosk_spring.dto.response;
+
+import teamkim.barrier_free_kiosk_spring.entity.Address;
+
+public record AddressGetResDto(
+        String sido,
+        String sigungu,
+        String roadName,
+        Integer buildingNumber,
+        String detail
+) {
+
+    public static AddressGetResDto from(Address address) {
+        return new AddressGetResDto(
+                address.getSido(),
+                address.getSigungu(),
+                address.getRoadName(),
+                address.getBuildingNumber(),
+                address.getDetailAddress()
+        );
+    }
+}

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/Address.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/Address.java
@@ -2,9 +2,11 @@ package teamkim.barrier_free_kiosk_spring.entity;
 
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import teamkim.barrier_free_kiosk_spring.dto.request.MoveInReportReqDto;
 
+@Getter
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/Address.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/Address.java
@@ -3,7 +3,7 @@ package teamkim.barrier_free_kiosk_spring.entity;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.NoArgsConstructor;
-import teamkim.barrier_free_kiosk_spring.dto.MoveInReportReqDto;
+import teamkim.barrier_free_kiosk_spring.dto.request.MoveInReportReqDto;
 
 @Embeddable
 @AllArgsConstructor

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/MoveInReportLog.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/MoveInReportLog.java
@@ -3,7 +3,7 @@ package teamkim.barrier_free_kiosk_spring.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import teamkim.barrier_free_kiosk_spring.dto.MoveInReportReqDto;
+import teamkim.barrier_free_kiosk_spring.dto.request.MoveInReportReqDto;
 import teamkim.barrier_free_kiosk_spring.enums.MoveInReason;
 
 @Entity

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/ResidentRegistrationLog.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/ResidentRegistrationLog.java
@@ -5,7 +5,7 @@ import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import teamkim.barrier_free_kiosk_spring.dto.ResidentRegistrationReqDto;
+import teamkim.barrier_free_kiosk_spring.dto.request.ResidentRegistrationReqDto;
 import teamkim.barrier_free_kiosk_spring.enums.RegistrationCopyType;
 
 @Entity

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/User.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/User.java
@@ -1,9 +1,11 @@
 package teamkim.barrier_free_kiosk_spring.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
 import teamkim.barrier_free_kiosk_spring.enums.Gender;
 
 @Entity
+@Getter
 public class User {
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/service/KioskService.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/service/KioskService.java
@@ -3,7 +3,7 @@ package teamkim.barrier_free_kiosk_spring.service;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import teamkim.barrier_free_kiosk_spring.dto.MoveInReportReqDto;
+import teamkim.barrier_free_kiosk_spring.dto.request.MoveInReportReqDto;
 import teamkim.barrier_free_kiosk_spring.entity.Address;
 import teamkim.barrier_free_kiosk_spring.entity.MoveInReportLog;
 import teamkim.barrier_free_kiosk_spring.entity.User;
@@ -11,7 +11,7 @@ import teamkim.barrier_free_kiosk_spring.exception.CustomException;
 import teamkim.barrier_free_kiosk_spring.exception.ExceptionCode;
 import teamkim.barrier_free_kiosk_spring.repository.LogRepository;
 import teamkim.barrier_free_kiosk_spring.repository.UserRepository;
-import teamkim.barrier_free_kiosk_spring.dto.ResidentRegistrationReqDto;
+import teamkim.barrier_free_kiosk_spring.dto.request.ResidentRegistrationReqDto;
 import teamkim.barrier_free_kiosk_spring.entity.ResidentRegistrationLog;
 
 @Service

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/service/KioskService.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/service/KioskService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import teamkim.barrier_free_kiosk_spring.dto.request.MoveInReportReqDto;
+import teamkim.barrier_free_kiosk_spring.dto.response.AddressGetResDto;
 import teamkim.barrier_free_kiosk_spring.entity.Address;
 import teamkim.barrier_free_kiosk_spring.entity.MoveInReportLog;
 import teamkim.barrier_free_kiosk_spring.entity.User;
@@ -44,5 +45,13 @@ public class KioskService {
 
     public Boolean checkPhoneNumber(String phoneNumber) {
         return userRepository.findByPhoneNumber(phoneNumber).isPresent();
+    }
+
+    public AddressGetResDto retrieveAddress(String name, String phoneNumber) {
+        return AddressGetResDto.from(
+                userRepository.findByPhoneNumberAndName(phoneNumber, name)
+                        .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND))
+                        .getAddress()
+        );
     }
 }

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,4 +1,4 @@
-INSERT INTO user
+INSERT IGNORE INTO user
 (name, phone_number, registration_number, gender, sido, sigungu, road_name, building_number, detail_address)
 VALUES
 ('장다윤1', '010-4171-7596', '010323-1234567', 'FEMALE', '대구광역시', '북구', '구암로', 21, '101동'),


### PR DESCRIPTION
### PR Type

- [ ] 버그수정(Bugfix)
- [x] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약
이름과 전화번호로 현재 주소를 조회하는 API를 구현했습니다. 

### 상세 내용
**Request**
```
/api/move-in/address?name=이시은&phoneNumber=010-6644-4534
```

**Response**
```json
{
    "sido": "대구광역시",
    "sigungu": "북구",
    "roadName": "산격로",
    "buildingNumber": "80",
    "detail": "융복합관 B101"
}
```

### 이슈 번호
Resolved #10

### 스크린샷(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 이름과 전화번호로 주소를 조회하는 GET /move-in/address 엔드포인트 추가(시/도, 시/군/구, 도로명, 건물번호, 상세 주소 반환).
* 리팩터
  * 전화번호 유효성 검사 경로를 /move-in → /move-in/check로 조정.
  * 일부 요청/응답 객체 위치 정리(기능 영향 없음).
* 작업
  * 초기 데이터 적재 시 중복 행을 건너뛰도록 개선해 오류 발생 가능성 감소.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->