### PR TITLE
전입신고 API 수정 #16

### DIFF
--- a/src/main/java/teamkim/barrier_free_kiosk_spring/dto/request/MoveInReportReqDto.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/dto/request/MoveInReportReqDto.java
@@ -9,7 +9,6 @@ public record MoveInReportReqDto(
         @NotBlank String name,
         @NotBlank String phoneNumber,
         @NotNull MoveInReason reason,
-        @NotNull @Valid Address oldAddress,
         @NotNull @Valid Address newAddress
 ) {
     public record Address(

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/entity/MoveInReportLog.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/entity/MoveInReportLog.java
@@ -43,7 +43,7 @@ public class MoveInReportLog extends Log {
     public static MoveInReportLog from(MoveInReportReqDto moveInReportReqDto, User user) {
         return new MoveInReportLog(
                 user,
-                Address.from(moveInReportReqDto.oldAddress()),
+                user.getAddress(),
                 Address.from(moveInReportReqDto.newAddress()),
                 moveInReportReqDto.reason()
         );

--- a/src/main/java/teamkim/barrier_free_kiosk_spring/service/KioskService.java
+++ b/src/main/java/teamkim/barrier_free_kiosk_spring/service/KioskService.java
@@ -26,9 +26,8 @@ public class KioskService {
         User user = userRepository.findByPhoneNumberAndName(moveInReportReqDto.phoneNumber(), moveInReportReqDto.name())
                 .orElseThrow(() -> new CustomException(ExceptionCode.USER_NOT_FOUND));
 
-        user.updateAddress(Address.from(moveInReportReqDto.newAddress()));
-
         MoveInReportLog moveInReportLog = logRepository.save(MoveInReportLog.from(moveInReportReqDto, user));
+        user.updateAddress(Address.from(moveInReportReqDto.newAddress()));
 
         return moveInReportLog.getId();
     }


### PR DESCRIPTION
### PR Type

- [x] 버그수정(Bugfix)
- [ ] 기능개발(Feature)
- [ ] 코드 스타일 변경(Code style update) (formatting, local variables)
- [ ] 리팩토링 (no functional changes, no api changes)
- [ ] 빌드 관련 변경
- [ ] 문서 내용 변경
- [ ] Other… Please describe:

### 요약
전입 신고 API를 수정했습니다.

### 상세 내용
**기존 Request**
```json
{
  "name": "string",
  "phoneNumber": "string",
  "reason": "JOB",
  "oldAddress": {
    "sido": "string",
    "sigungu": "string",
    "roadName": "string",
    "buildingNumber": 0,
    "detail": "string"
  },
  "newAddress": {
    "sido": "string",
    "sigungu": "string",
    "roadName": "string",
    "buildingNumber": 0,
    "detail": "string"
  }
}
```

**수정할 Request**
```json
{
  "name": "string",
  "phoneNumber": "string",
  "reason": "JOB",
  "newAddress": {
    "sido": "string",
    "sigungu": "string",
    "roadName": "string",
    "buildingNumber": 0,
    "detail": "string"
  }
}
```

### 이슈 번호
Resolved #16 

### 스크린샷(선택)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 전입 신고 시 이전 주소 입력 없이 진행 가능(입력 항목 축소). 사용자의 기존 주소를 자동으로 활용해 작성 시간을 단축합니다.
- 버그 수정
  - 전입 신고 로그가 주소 변경 전 상태를 정확히 기록하도록 처리 순서를 조정해 기록의 일관성과 신뢰성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->